### PR TITLE
Restructure pages

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,7 @@ and model management. Pleas see the presentation below to learn more:
    </p>
 
 
-If you want to play with LLM Operator, check out :doc:`tutorial`. You can install LLM Operator in a Kind cluster by following the steps described here.
+If you want to play with LLM Operator, check out :doc:`playground`. You can install LLM Operator in a Kind cluster by following the steps described there.
 You can also just directly move to the :doc:`install` section and install LLM Operator to your Kubernetes clusters!
 
 
@@ -34,8 +34,9 @@ Contents
 
 .. toctree::
 
-   tutorial
+   playground
    install
+   tutorials
    inference
    models
    rag

--- a/docs/source/playground.rst
+++ b/docs/source/playground.rst
@@ -1,8 +1,8 @@
-Tutorial
-========
+Set up a Playground
+===================
 
-In this tutorial, we provision an EC2 instance, build a `Kind <https://kind.sigs.k8s.io/>`_ cluster, and
-deploy LLM Operator and other required components.
+You can easily set up a playground for LLM Operator and learn it. In this page, we provision an EC2 instance, build
+a `Kind <https://kind.sigs.k8s.io/>`_ cluster, and deploy LLM Operator and other required components.
 
 Once all the setup completes, you can interact with the LLM service
 by directly hitting the API endpoints or using `the OpenAI Python library <https://github.com/openai/openai-python>`_.
@@ -189,8 +189,9 @@ The third option is to use Python. Here is an example Python code for hitting th
      print(response.choices[0].delta.content, end="")
    print("\n")
 
-We have a Jupyter Notebook that goes through all the functionalites. Please download the Notebook
-from https://github.com/llm-operator/llm-operator/blob/main/tutorial/getting_started.ipynb to play around it.
+
+Please visit :doc:`tutorials` to further exercise LLM Operator.
+
 
 Step 7: Clean up
 ----------------

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,0 +1,10 @@
+Tutorials
+=========
+
+.. note::
+
+   Work-in-progress.
+
+Here are the links to the tutorials. You can download the Jupyter Notebooks and exercise the tutorials.
+
+- https://github.com/llm-operator/llm-operator/blob/main/tutorial/getting_started.ipynb


### PR DESCRIPTION
- Rename "Tutorial" to "Set up a Playground"
- Create a separate "Tutorials" page. Currently it contains only a link.